### PR TITLE
we don't support php 5.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 5.4
+    - php: 5.5
       env:
         - COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
         - COVERAGE=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ cache:
     - $HOME/.composer/cache
 
 php:
-  - 5.4
   - 5.5
   - 5.6
   - 7.0
@@ -18,8 +17,6 @@ env:
     - TEST_COMMAND="phpunit"
 
 matrix:
-  allow_failures:
-    - php: 7.0
   fast_finish: true
   include:
     - php: 5.4


### PR DESCRIPTION
i activated travis for this repository and noticed it tries to build with php 5.4, then composer notices that this wont work.

i suggest we activate php 7 as well. its about to be released, and currently green.