### PR TITLE
Corrected a problem with memory

### DIFF
--- a/src/ResponseParser.php
+++ b/src/ResponseParser.php
@@ -13,6 +13,7 @@ use Psr\Http\Message\ResponseInterface;
  * @license http://opensource.org/licenses/MIT MIT
  *
  * @author  Михаил Красильников <m.krasilnikov@yandex.ru>
+ * @author  Dmitry Arhitector   <dmitry.arhitector@yandex.ru>
 */
 class ResponseParser
 {
@@ -39,7 +40,7 @@ class ResponseParser
     protected $streamFactory;
 
     /**
-     *
+     * Temporary resource
      *
      * @var resource
      */
@@ -120,8 +121,7 @@ class ResponseParser
 
         $parser = new HeadersParser();
 
-        $response = $this->messageFactory->createResponse();
-        $response = $parser->parseArray($this->headers, $response);
+        $response = $parser->parseArray($this->headers, $this->messageFactory->createResponse());
         $response = $response->withBody($this->streamFactory->createStream($raw));
 
         $this->temporaryStream = null;
@@ -129,6 +129,14 @@ class ResponseParser
         return $response;
     }
 
+    /**
+     * Save the response headers
+     * 
+     * @param   resource    $handler    curl handler
+     * @param   string      $header     raw header
+     * 
+     * @return integer
+     */
     public function headerHandler($handler, $header)
     {
         $this->headers[] = $header;
@@ -138,7 +146,7 @@ class ResponseParser
             $this->headers = [$header];
         } else if ( ! trim($header)) {
             $this->followLocation = true;
-            //$this->parse();
+            //$this->parse(null, []);
         }
 
         return strlen($header);

--- a/src/ResponseParser.php
+++ b/src/ResponseParser.php
@@ -124,6 +124,8 @@ class ResponseParser
         $response = $parser->parseArray($this->headers, $response);
         $response = $response->withBody($this->streamFactory->createStream($raw));
 
+        $this->temporaryStream = null;
+
         return $response;
     }
 

--- a/src/Tools/HeadersParser.php
+++ b/src/Tools/HeadersParser.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Http\Client\Curl\Tools;
 
 use Psr\Http\Message\ResponseInterface;


### PR DESCRIPTION
I have corrected some inconvenient moments and have up to the end corrected a problem with memory.

fix inheritance support.
fix custom reading function (CURLOPT_READFUNCTION).
fix custom methods.
fix "Expect" and "Accept" header.
fix PATCH with send body.
fix support native PHP stream filters.
fix support follow location (CURLOPT_FOLLOWLOCATION).
fix compatible stream with PSR-7 specifications.
fix out of memory when a large body send of response.
fix out of memory with sendAsyncRequest in some cases.