### PR TITLE
Make sure we rewind streams

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -278,6 +278,10 @@ class Client implements HttpClient, HttpAsyncClient
             $body = $request->getBody();
             $bodySize = $body->getSize();
             if ($bodySize !== 0) {
+                if ($body->isSeekable()) {
+                    $body->rewind();
+                }
+
                 // Message has non empty body.
                 if (null === $bodySize || $bodySize > 1024 * 1024) {
                     // Avoid full loading large or unknown size body into memory


### PR DESCRIPTION
Guzzle and socket client rewinds streams. We should as well. 

See discussion: https://github.com/php-http/message/pull/72