### PR TITLE
PHPUnit 6 compatability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "require-dev": {
         "guzzlehttp/psr7": "^1.0",
-        "php-http/client-integration-tests": "^0.5.1",
+        "php-http/client-integration-tests": "^0.6",
         "phpunit/phpunit": "^4.8.27",
         "zendframework/zend-diactoros": "^1.0"
     },

--- a/tests/BaseUnitTestCase.php
+++ b/tests/BaseUnitTestCase.php
@@ -3,13 +3,14 @@ namespace Http\Client\Curl\Tests;
 
 use Http\Client\Curl\PromiseCore;
 use Http\Discovery\MessageFactoryDiscovery;
+use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
 /**
  * Base class for unit tests
  */
-abstract class BaseUnitTestCase extends \PHPUnit_Framework_TestCase
+abstract class BaseUnitTestCase extends TestCase
 {
     /**
      * Test cURL handle

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -3,6 +3,7 @@ namespace Http\Client\Curl\Tests;
 
 use GuzzleHttp\Psr7\Stream;
 use Http\Client\Curl\Client;
+use PHPUnit\Framework\TestCase;
 use Zend\Diactoros\Request;
 
 /**
@@ -10,7 +11,7 @@ use Zend\Diactoros\Request;
  *
  * @covers Http\Client\Curl\Client
  */
-class ClientTest extends \PHPUnit_Framework_TestCase
+class ClientTest extends TestCase
 {
     /**
      * "Expect" header should be empty


### PR DESCRIPTION
This will allow use to use phpunit 6. Older versions are still supported. 

This will allow the integration tests repo to run curl tests on travis. 