### PR TITLE
Use isset over array_key_exists

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -1,5 +1,5 @@
 <?php
-
+declare(strict_types=1);
 namespace Http\Client\Curl;
 
 use Http\Client\Exception;
@@ -330,10 +330,10 @@ class Client implements HttpClient, HttpAsyncClient
                 continue;
             }
             if ('content-length' === $header) {
-                if (array_key_exists(CURLOPT_POSTFIELDS, $options)) {
+                if (isset($options[CURLOPT_POSTFIELDS])) {
                     // Small body content length can be calculated here.
                     $values = [strlen($options[CURLOPT_POSTFIELDS])];
-                } elseif (!array_key_exists(CURLOPT_READFUNCTION, $options)) {
+                } elseif (!isset($options[CURLOPT_READFUNCTION])) {
                     // Else if there is no body, forcing "Content-length" to 0
                     $values = [0];
                 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -51,7 +51,7 @@ class ClientTest extends TestCase
 
         $headers = $createHeaders->invoke($client, $request, [CURLOPT_POSTFIELDS => null]);
 
-        static::assertContains('Expect:', $headers);
+        static::assertContains('content-length: 0', $headers);
     }
 
     public function testRewindStream()

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -33,6 +33,27 @@ class ClientTest extends TestCase
         static::assertContains('Expect:', $headers);
     }
 
+    /**
+     * "Expect" header should be empty.
+     *
+     * @link https://github.com/php-http/curl-client/issues/18
+     */
+    public function testWithNullPostFields()
+    {
+        $client = $this->getMockBuilder(Client::class)->disableOriginalConstructor()
+            ->setMethods(['__none__'])->getMock();
+
+        $createHeaders = new \ReflectionMethod(Client::class, 'createHeaders');
+        $createHeaders->setAccessible(true);
+
+        $request = new Request();
+        $request = $request->withHeader('content-length', 0);
+
+        $headers = $createHeaders->invoke($client, $request, [CURLOPT_POSTFIELDS => null]);
+
+        static::assertContains('Expect:', $headers);
+    }
+
     public function testRewindStream()
     {
         $client = $this->getMockBuilder(Client::class)->disableOriginalConstructor()

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -47,7 +47,7 @@ class ClientTest extends TestCase
         $createHeaders->setAccessible(true);
 
         $request = new Request();
-        $request = $request->withHeader('content-length', 0);
+        $request = $request->withHeader('content-length', '0');
 
         $headers = $createHeaders->invoke($client, $request, [CURLOPT_POSTFIELDS => null]);
 


### PR DESCRIPTION
if for whatever weird reason someone sets `CURLOPT_POSTFIELDS` sets it us null and you also enable strict types in php7 then `strlen(null)` will blow up