### PR TITLE
Remove set methods and lock phpunit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "require-dev": {
         "guzzlehttp/psr7": "^1.0",
         "php-http/client-integration-tests": "dev-master",
-        "phpunit/phpunit": "^7.0",
+        "phpunit/phpunit": "^7.5",
         "zendframework/zend-diactoros": "^1.0"
     },
     "autoload": {

--- a/tests/BaseUnitTestCase.php
+++ b/tests/BaseUnitTestCase.php
@@ -63,15 +63,6 @@ abstract class BaseUnitTestCase extends TestCase
      */
     protected function createPromiseCore()
     {
-        $class = new \ReflectionClass(PromiseCore::class);
-        $methods = $class->getMethods(\ReflectionMethod::IS_PUBLIC);
-        foreach ($methods as &$item) {
-            $item = $item->getName();
-        }
-        unset($item);
-        $core = $this->getMockBuilder(PromiseCore::class)->disableOriginalConstructor()
-            ->setMethods($methods)->getMock();
-
-        return $core;
+        return $this->getMockBuilder(PromiseCore::class)->disableOriginalConstructor()->getMock();
     }
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -25,8 +25,7 @@ class ClientTest extends TestCase
      */
     public function testExpectHeader()
     {
-        $client = $this->getMockBuilder(Client::class)->disableOriginalConstructor()
-            ->setMethods(['__none__'])->getMock();
+        $client = $this->getMockBuilder(Client::class)->disableOriginalConstructor()->getMock();
 
         $createHeaders = new \ReflectionMethod(Client::class, 'createHeaders');
         $createHeaders->setAccessible(true);
@@ -38,10 +37,29 @@ class ClientTest extends TestCase
         static::assertContains('Expect:', $headers);
     }
 
+    /**
+     * "Expect" header should be empty.
+     *
+     * @link https://github.com/php-http/curl-client/issues/18
+     */
+    public function testWithNullPostFields()
+    {
+        $client = $this->getMockBuilder(Client::class)->disableOriginalConstructor()->getMock();
+
+        $createHeaders = new \ReflectionMethod(Client::class, 'createHeaders');
+        $createHeaders->setAccessible(true);
+
+        $request = new Request();
+        $request = $request->withHeader('content-length', '0');
+
+        $headers = $createHeaders->invoke($client, $request, [CURLOPT_POSTFIELDS => null]);
+
+        static::assertContains('content-length: 0', $headers);
+    }
+
     public function testRewindStream()
     {
-        $client = $this->getMockBuilder(Client::class)->disableOriginalConstructor()
-            ->setMethods(['__none__'])->getMock();
+        $client = $this->getMockBuilder(Client::class)->disableOriginalConstructor()->getMock();
 
         $bodyOptions = new \ReflectionMethod(Client::class, 'addRequestBodyOptions');
         $bodyOptions->setAccessible(true);
@@ -56,8 +74,7 @@ class ClientTest extends TestCase
 
     public function testRewindLargeStream()
     {
-        $client = $this->getMockBuilder(Client::class)->disableOriginalConstructor()
-            ->setMethods(['__none__'])->getMock();
+        $client = $this->getMockBuilder(Client::class)->disableOriginalConstructor()->getMock();
 
         $bodyOptions = new \ReflectionMethod(Client::class, 'addRequestBodyOptions');
         $bodyOptions->setAccessible(true);

--- a/tests/CurlPromiseTest.php
+++ b/tests/CurlPromiseTest.php
@@ -57,8 +57,7 @@ class CurlPromiseTest extends BaseUnitTestCase
     public function testCoreCallWaitRejected()
     {
         $core = $this->createPromiseCore();
-        $runner = $this->getMockBuilder(MultiRunner::class)->disableOriginalConstructor()
-            ->setMethods(['wait'])->getMock();
+        $runner = $this->getMockBuilder(MultiRunner::class)->disableOriginalConstructor()->getMock();
         /** @var MultiRunner|\PHPUnit_Framework_MockObject_MockObject $runner */
         $promise = new CurlPromise($core, $runner);
 

--- a/tests/PromiseCoreTest.php
+++ b/tests/PromiseCoreTest.php
@@ -23,10 +23,8 @@ class PromiseCoreTest extends BaseUnitTestCase
      */
     public function testHandleIsNotAResource()
     {
-        $this->expectException(
-            \InvalidArgumentException::class,
-            'Parameter $handle expected to be a cURL resource, NULL given'
-        );
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Parameter $handle expected to be a cURL resource, NULL given');
 
         new PromiseCore(
             $this->createRequest('GET', '/'),
@@ -40,10 +38,8 @@ class PromiseCoreTest extends BaseUnitTestCase
      */
     public function testHandleIsNotACurlResource()
     {
-        $this->expectException(
-            \InvalidArgumentException::class,
-            'Parameter $handle expected to be a cURL resource, stream resource given'
-        );
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Parameter $handle expected to be a cURL resource, stream resource given');
 
         new PromiseCore(
             $this->createRequest('GET', '/'),


### PR DESCRIPTION
1. I have remove setMethods of PHPUnit... since it does not add any extra value having them.
2. Fixed the expectExceptionMessage.
3. Locked to PHPUnit 7.5.The library has some deprecations. Locking this will avoid having someone using them... And also it has more features.. so in this way we are allowed to use them...

