### PR TITLE
State that the curl-client provides a http client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,8 @@
     },
     "provide": {
         "php-http/client-implementation": "1.0",
-        "php-http/async-client-implementation": "1.0"
+        "php-http/async-client-implementation": "1.0",
+        "psr/http-client-implementation": "1.0"
     },
     "scripts": {
         "test": "vendor/bin/phpunit",


### PR DESCRIPTION
Currently, package requiring a `psr/http-client-implementation` can't use this client because it doesn't seem to provide it.