### PR TITLE
Cast CURL constants to string that cause a InvalidArgumentException

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -94,13 +94,13 @@ class Client implements HttpClient, HttpAsyncClient
 
         // Our parsing will fail if this is set to true.
         $resolver->setAllowedValues(
-            CURLOPT_HEADER,
+            (string)CURLOPT_HEADER,
             [false]
         );
 
         // Our parsing will fail if this is set to true.
         $resolver->setAllowedValues(
-            CURLOPT_RETURNTRANSFER,
+            (string)CURLOPT_RETURNTRANSFER,
             [false]
         );
 


### PR DESCRIPTION
Followup on https://github.com/php-http/curl-client/pull/62

After some quick testing, I noticed some inconsistencies because the Symfony source code doesn't use strict typing. So when you pass the CURL constants as array keys, it will be converted to strings by the `OptionsResolver` itself.

```php
# This works
        $resolver->setDefaults(
            [
                CURLOPT_HEADER => false
            ]
        );

# This doesn't work
        $resolver->setDefault(CURLOPT_HEADER, false);
```