### PR TITLE
PHP 8: Add support for CurlHandle resource objects

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -53,7 +53,7 @@ class Client implements HttpClient, HttpAsyncClient
     /**
      * cURL synchronous requests handle.
      *
-     * @var resource|null
+     * @var resource|\CurlHandle|null
      */
     private $handle;
 

--- a/src/PromiseCore.php
+++ b/src/PromiseCore.php
@@ -69,9 +69,9 @@ class PromiseCore
     /**
      * Create shared core.
      *
-     * @param RequestInterface $request HTTP request.
-     * @param resource         $handle cURL handle.
-     * @param ResponseBuilder  $responseBuilder Response builder.
+     * @param RequestInterface    $request HTTP request.
+     * @param resource|CurlHandle $handle cURL handle.
+     * @param ResponseBuilder     $responseBuilder Response builder.
      *
      * @throws \InvalidArgumentException If $handle is not a cURL resource.
      */
@@ -80,7 +80,7 @@ class PromiseCore
         $handle,
         ResponseBuilder $responseBuilder
     ) {
-        if (!is_resource($handle)) {
+        if (!is_resource($handle) && !(is_object($handle) && $handle instanceof \GdImage)) {
             throw new \InvalidArgumentException(
                 sprintf(
                     'Parameter $handle expected to be a cURL resource, %s given',
@@ -89,7 +89,7 @@ class PromiseCore
             );
         }
 
-        if (get_resource_type($handle) !== 'curl') {
+        if (is_resource($handle) && get_resource_type($handle) !== 'curl') {
             throw new \InvalidArgumentException(
                 sprintf(
                     'Parameter $handle expected to be a cURL resource, %s resource given',
@@ -138,7 +138,7 @@ class PromiseCore
     /**
      * Return cURL handle.
      *
-     * @return resource
+     * @return resource|\CurlHandle
      */
     public function getHandle()
     {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?         | yes
| New feature?    | no|yes
| BC breaks?      | no|yes
| Deprecations?   | no|yes
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| Documentation   | if this is a new feature, link to pull request in https://github.com/php-http/documentation that adds relevant documentation
| License         | MIT


#### What's in this PR?

In PHP 8.0, [Curl resources are changed to CurlHandle class objects](https://php.watch/versions/8.0/resource-CurlHandle#is-resource). This changes DocBlock parameters and other areas where provided handles are checked with `is_resource()`, which now needs to account for the replaced `CurlHandle` class objects.


#### Why?

Because in PHP 8.0, Curl handles are no longer resources, and this libraries `is_resource` no longer return true for valid Curl handlers.


#### Example Usage

``` php
is_resource(curl_init()); // true in PHP < 8.0
is_resource(curl_init()); // false in PHP >= 8.0
```


#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)

