### PR TITLE
Added symfony/options-resolver 6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "php-http/message": "^1.2",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
-        "symfony/options-resolver": "^3.4 || ^4.0 || ^5.0"
+        "symfony/options-resolver": "^3.4 || ^4.0 || ^5.0 || ^6.0"
     },
     "require-dev": {
         "guzzlehttp/psr7": "^1.0",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?         | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | N/A
| Documentation   | N/A
| License         | MIT


#### What's in this PR?

Added symfony/options-resolver:^6.0 to composer.json and verified the tests.

#### Why?

So php-http/curl-client can be used together with Symfony 6.
The symfony/options-resolver:6.0 has "no significant changes" according the changelog and should be compatible.

#### Example Usage
-

#### Checklist
-

#### To Do
-
