### PR TITLE
install legacy factory to still test it

### DIFF
--- a/.github/workflows/Build-Test.yml
+++ b/.github/workflows/Build-Test.yml
@@ -14,10 +14,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        operating-system: [ubuntu-20.04]
+        operating-system: [ubuntu-22.04]
         php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
         include:
-          - operating-system: ubuntu-16.04
+          - operating-system: ubuntu-20.04
             php-versions: '7.1'
             COMPOSER_FLAGS: '--prefer-stable --prefer-lowest'
             PHPUNIT_FLAGS: '--coverage-clover build/coverage.xml'

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         "guzzlehttp/psr7": "^1.0",
         "php-http/client-integration-tests": "^3.0",
         "phpunit/phpunit": "^7.5 || ^9.4",
-        "laminas/laminas-diactoros": "^2.0"
+        "laminas/laminas-diactoros": "^2.0",
+        "php-http/message-factory": "^1.1"
     },
     "autoload": {
         "psr-4": {
@@ -48,5 +49,10 @@
     "scripts": {
         "test": "vendor/bin/phpunit",
         "test-ci": "vendor/bin/phpunit --coverage-clover build/coverage.xml"
+    },
+    "config": {
+        "allow-plugins": {
+            "php-http/discovery": false
+        }
     }
 }


### PR DESCRIPTION
php-http/message-factory has been superseded by psr 17 and is no longer automatically installed. but we want to still test with it for as long as we support it.