### PR TITLE
Add Support for PHP 8.4

### DIFF
--- a/.github/workflows/Build-Test.yml
+++ b/.github/workflows/Build-Test.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ubuntu-22.04]
-        php-versions: ['7.4', '8.0', '8.1', '8.2', '8.3']
+        php-versions: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
         include:
           - operating-system: ubuntu-20.04
             php-versions: '7.4'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.4.0
+
+### Added
+
+- Added support for PHP 8.4
+
 ## 2.3.2 - 2024-03-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 2.4.0
+## 2.3.3 - 2024-10-31
 
 ### Added
 

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "guzzlehttp/psr7": "^2.0",
         "php-http/client-integration-tests": "^3.0",
         "phpunit/phpunit": "^7.5 || ^9.4",
-        "laminas/laminas-diactoros": "^2.0",
+        "laminas/laminas-diactoros": "^2.0 || ^3.0",
         "php-http/message-factory": "^1.1"
     },
     "autoload": {

--- a/src/Client.php
+++ b/src/Client.php
@@ -77,8 +77,8 @@ class Client implements HttpClient, HttpAsyncClient
      * @since 2.0 Accepts PSR-17 factories instead of HTTPlug ones.
      */
     public function __construct(
-        ResponseFactoryInterface $responseFactory = null,
-        StreamFactoryInterface $streamFactory = null,
+        ?ResponseFactoryInterface $responseFactory = null,
+        ?StreamFactoryInterface $streamFactory = null,
         array $options = []
     ) {
         $this->responseFactory = $responseFactory ?: Psr17FactoryDiscovery::findResponseFactory();

--- a/src/CurlPromise.php
+++ b/src/CurlPromise.php
@@ -51,15 +51,15 @@ class CurlPromise implements Promise
      * If you do not care about one of the cases, you can set the corresponding callable to null
      * The callback will be called when the response or exception arrived and never more than once.
      *
-     * @param callable $onFulfilled Called when a response will be available
-     * @param callable $onRejected  Called when an error happens.
+     * @param callable|null $onFulfilled Called when a response will be available
+     * @param callable|null $onRejected  Called when an error happens.
      *
      * You must always return the Response in the interface or throw an Exception
      *
      * @return Promise Always returns a new promise which is resolved with value of the executed
      *                 callback (onFulfilled / onRejected)
      */
-    public function then(callable $onFulfilled = null, callable $onRejected = null)
+    public function then(?callable $onFulfilled = null, ?callable $onRejected = null)
     {
         if ($onFulfilled) {
             $this->core->addOnFulfilled($onFulfilled);

--- a/src/MultiRunner.php
+++ b/src/MultiRunner.php
@@ -81,7 +81,7 @@ class MultiRunner
      *
      * @param PromiseCore|null $targetCore
      */
-    public function wait(PromiseCore $targetCore = null): void
+    public function wait(?PromiseCore $targetCore = null): void
     {
         do {
             $status = curl_multi_exec($this->multiHandle, $active);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?         | yes
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT


#### What's in this PR?

Adds PHP 8.4 to the test matrix, explicitly marks nullable parameters as nullable.


#### Why?

Implicit nulls are deprecated on 8.4

#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix

