### PR TITLE
ci: Add Support for PHP 8.5

### DIFF
--- a/.github/workflows/Build-Test.yml
+++ b/.github/workflows/Build-Test.yml
@@ -17,7 +17,7 @@ jobs:
         operating-system: [ubuntu-22.04]
         php-versions: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
         include:
-          - operating-system: ubuntu-20.04
+          - operating-system: ubuntu-22.04
             php-versions: '7.4'
             COMPOSER_FLAGS: '--prefer-stable --prefer-lowest'
             PHPUNIT_FLAGS: '--coverage-clover build/coverage.xml'

--- a/.github/workflows/Build-Test.yml
+++ b/.github/workflows/Build-Test.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ubuntu-22.04]
-        php-versions: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php-versions: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
         include:
           - operating-system: ubuntu-20.04
             php-versions: '7.4'
@@ -31,7 +31,7 @@ jobs:
     steps:
       # Checks out a copy of your repository on the ubuntu machine
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup PHP Action
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
actions/checkout 4 => 6
ubuntu-20.04 => ubuntu-22.04 (v 20 is not supported anymore on github runners)